### PR TITLE
Lpx api v3.0

### DIFF
--- a/api-spec-documentation/swagger.yaml
+++ b/api-spec-documentation/swagger.yaml
@@ -178,7 +178,7 @@ components:
         headlines:
           type: array
           items:
-            $ref: '#/components/schemas/Eventheadlines'
+            $ref: '#/components/schemas/EventHeadlines'
             
         people:
           type: array
@@ -188,7 +188,7 @@ components:
         organisations:
           type: array
           items:
-            $ref: '#/components/schemas/OrganisationType'   
+            $ref: '#/components/schemas/organisationType'   
         
         places:
           type: array
@@ -240,7 +240,7 @@ components:
         renditions: 
           type: array
           items: 
-            $ref: '#/components/schemas/EventRenditionType'
+            $ref: '#/components/schemas/renditionType'
             
         associations:
           type: array
@@ -363,7 +363,7 @@ components:
           type: integer
         y:
           type: integer
-    EventRenditionType:
+    renditionType:
       type: object
       properties:
         items:
@@ -384,15 +384,46 @@ components:
         href:
           type: string
           format: uri
+        code:
+          type: string
+        signal:
+          type: string
         transportprotocol: 
           type: string
           enum: 
             - srtlistener
             - srtcaller
-        code:
+        maxbitrate:
+          type: number
+        cidr:
           type: string
-        signal:
+        port:
+          type: number
+        srtpassword:
           type: string
+        listeneraddress:
+          type: string
+        streamid:
+          type: string
+        minlatency:
+          type: number
+        codec:
+          type: string
+        scantype:
+          type: string
+          enum:
+            - progressive
+            - interlaced
+        bitrate:
+          type: number
+        gop:
+          type: number
+        ratecontrolmode:
+          type: string
+          enum:
+            - CBR
+            - VBR
+            - QVBR
         contenttype:
           type: string
         title:
@@ -420,6 +451,8 @@ components:
           type: string
         samplerate:
           type: number
+        audiochannels:
+          type: number
         audiobitrate:
           type: number
         aspectratio:
@@ -442,10 +475,12 @@ components:
           type: string
         scene:
           type: string
+        printsize:
+          type: number
         poi:
           $ref: '#/components/schemas/EventRenditionTypepoi'
           
-    EventcommissionedType: 
+    commissionedType: 
       type: object
       additionalProperties: false
       properties: 
@@ -491,13 +526,13 @@ components:
         dates:
             $ref: '#/components/schemas/datesobjectType'
         organiser:
-            $ref: '#/components/schemas/OrganisationType'
+            $ref: '#/components/schemas/organisationType'
 
       additionalProperties: false
       
       
       
-    Eventheadlines:
+    EventHeadlines:
       type: array
       items:
         type: object
@@ -617,7 +652,7 @@ components:
               - withheld
               - canceled  
           commissioned: 
-            $ref: '#/components/schemas/EventcommissionedType'
+            $ref: '#/components/schemas/commissionedType'
             
           dates:
             $ref: '#/components/schemas/datesobjectType'
@@ -684,7 +719,7 @@ components:
           renditions:
             type: array
             items:
-              $ref: '#/components/schemas/EventRenditionType'
+              $ref: '#/components/schemas/renditionType'
     
     
     
@@ -894,7 +929,7 @@ components:
         startdate:
           $ref: '#/components/schemas/truncatedDateTimeType'
         enddate:
-            $ref: '#/components/schemas/truncatedDateTimeType'
+          $ref: '#/components/schemas/truncatedDateTimeType'
         duration:
           
           type: string
@@ -909,14 +944,12 @@ components:
                 $ref: '#/components/schemas/truncatedDateTimeType'
             recurrence-rules:
               type: array
-              
               items:
                 type: object
                 additionalProperties: false
                 properties:
                   frequency:
                     type: string
-                    
                     enum:
                       - secondly
                       - minutely
@@ -935,7 +968,7 @@ components:
                     type: string
     
 
-    OrganisationType:
+    organisationType:
       type: object
       additionalProperties: false
       properties:

--- a/api-spec-documentation/swagger.yaml
+++ b/api-spec-documentation/swagger.yaml
@@ -1,0 +1,978 @@
+openapi: 3.0.0
+info:
+  title: LPX API
+  version: '3.0'
+servers:
+  - url: /
+paths:
+  /events:
+    get:
+      summary: Select Event
+      responses:
+        '200':
+          description: Event details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '404':
+          description: Event not found
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: arn:aws:apigateway:${base_region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${base_region}:${aws_account_id}:function:${environment}-select_event/invocations
+        httpMethod: POST
+        credentials: arn:aws:iam::${aws_account_id}:role/${environment}-profile_delete_lambda-invokelambdarole
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 5000
+    put:
+      summary: Update Event
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+        required: true
+      responses:
+        '200':
+          description: Event updated
+        '404':
+          description: Event not found
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: arn:aws:apigateway:${base_region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${base_region}:${aws_account_id}:function:${environment}-update_event/invocations
+        httpMethod: POST
+        credentials: arn:aws:iam::${aws_account_id}:role/${environment}-profile_delete_lambda-invokelambdarole
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 5000
+    post:
+      summary: Create Event
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+        required: true
+      responses:
+        '201':
+          description: Event created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inlineresponse201'
+        '400':
+          description: Invalid input
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: arn:aws:apigateway:${base_region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${base_region}:${aws_account_id}:function:${environment}-create_event/invocations
+        httpMethod: POST
+        credentials: arn:aws:iam::${aws_account_id}:role/${environment}-profile_delete_lambda-invokelambdarole
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 5000
+    delete:
+      summary: Delete Event
+      responses:
+        '200':
+          description: Event deleted
+        '404':
+          description: Event not found
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: arn:aws:apigateway:${base_region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${base_region}:${aws_account_id}:function:${environment}-delete_event/invocations
+        httpMethod: POST
+        credentials: arn:aws:iam::${aws_account_id}:role/${environment}-profile_delete_lambda-invokelambdarole
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 5000
+  /events/list:
+    get:
+      summary: List Events
+      responses:
+        '200':
+          description: An array of events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: arn:aws:apigateway:${base_region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${base_region}:${aws_account_id}:function:${environment}-list_events/invocations
+        httpMethod: POST
+        credentials: arn:aws:iam::${aws_account_id}:role/${environment}-profile_delete_lambda-invokelambdarole
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 5000
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        uri:
+          type: string
+        type:
+          type: string
+          enum:
+            - text
+            - audio
+            - video
+            - picture
+            - graphic
+            - composite
+            - component
+            - event
+            - planning
+        representationtype:
+          type: string
+          description: Indicates how complete this representation of a news item is. No mapping to nar. Specific for ninjs.
+          enum:
+            - full
+            - partial
+        profile:
+          type: string
+        
+        version:
+          type: string
+        
+        versioncreated:
+          type: string
+          format: date-time
+          
+        contentcreated:
+          type: string
+          format: date-time
+        
+
+        embargoed:
+          type: string
+          format: date-time
+        
+        
+        urgency:
+          type: number
+        
+        copyrightholder:
+          type: string
+          
+        copyrightnotice:
+          type: string 
+          
+        usageterms:
+          type: string 
+        
+        ednote:
+          type: string 
+        
+        language:
+          type: string
+        
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventdescriptions'
+        
+        bodies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventbodies'
+            
+        
+        headlines:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventheadlines'
+            
+        people:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventpeople'
+            
+        organisations:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganisationType'   
+        
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventPlaces'    
+          
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventSubjects'
+        
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Events'
+        
+        eventdetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventDetails'
+        
+        plannedcoverage:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventPlannedCoverage'  
+            
+        objects:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventObjects'  
+            
+        infosources:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventinfosources' 
+            
+        title:
+          type: string
+          
+        by:
+          type: string 
+          
+        slugline:
+          type: string  
+          
+        located:
+          type: string
+          
+        renditions: 
+          type: array
+          items: 
+            $ref: '#/components/schemas/EventRenditionType'
+            
+        associations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventassociations'  
+            
+        altids:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventAltIds'
+          
+        trustindicators:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventtrustindicators'  
+            
+        standard:
+          type: object
+          items:
+            $ref: '#/components/schemas/Eventstandard'  
+            
+        genres:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eventgenres' 
+            
+        expires:
+          type: string
+          format: date-time
+          
+        rightsinfo:
+          type: object
+          items:
+            $ref: '#/components/schemas/Eventrightsinfo' 
+
+            
+    inlineresponse201:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the created event
+    
+    Eventbodies:
+      type: array
+      items:
+        type: object
+        required: [value]
+        additionalProperties: false
+        properties:
+          role:
+            type: string
+            title: Role
+          contenttype:
+            type: string
+          charcount:
+            type: integer
+          wordcount:
+            type: integer
+            
+          value:
+            type: string
+            
+    
+    Eventdescriptions:
+      type: array
+      items:
+        type: object
+        required: [value]
+        additionalProperties: false
+        properties:
+          role:
+            type: string
+          contenttype:
+            type: string
+          value:
+            type: string
+    
+    Events:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            
+          name:
+            type: string
+            
+          rel:
+            type: string
+            
+          uri:
+            type: string
+            format: uri
+            
+          literal:
+            type: string
+            
+        additionalProperties: false
+        
+    
+    EventAltIds:
+      type: array
+      items:
+        type: object
+        properties:
+          role:
+            type: string
+            description: The role of the alternative id
+          value:
+            type: string
+            description: The alternative id value
+        additionalProperties: false
+            
+    EventRenditionTypepoi:
+      type: object
+      properties:
+        x:
+          type: integer
+        y:
+          type: integer
+    EventRenditionType:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+        name:
+          title: Name
+          type: string
+        uri:
+          type: string
+          format: uri
+        version:
+          type: integer
+        versionguid:
+          type: string
+        href:
+          type: string
+          format: uri
+        transportprotocol: 
+          type: string
+          enum: 
+            - srtlistener
+            - srtcaller
+        code:
+          type: string
+        signal:
+          type: string
+        contenttype:
+          type: string
+        title:
+          type: string
+        generated:
+          type: string
+          format: date-time
+        height:
+          type: number
+        width:
+          type: number
+        sizeinbytes:
+          type: number
+        duration:
+          type: number
+        averagebitrate:
+          type: number
+        format:
+          type: string
+        originalfilename:
+          type: string
+        fileextension:
+          type: string
+        digest:
+          type: string
+        samplerate:
+          type: number
+        audiobitrate:
+          type: number
+        aspectratio:
+          type: string
+        colourspace:
+          type: string
+        backgroundcolour:
+          type: string
+        orientation:
+          type: string
+        videocodec:
+          type: string
+        videoscaling:
+          type: string
+        framerate:
+          type: number
+        resolution:
+          type: string
+        audiocodec:
+          type: string
+        scene:
+          type: string
+        poi:
+          $ref: '#/components/schemas/EventRenditionTypepoi'
+          
+    EventcommissionedType: 
+      type: object
+      additionalProperties: false
+      properties: 
+        by: 
+          type: string
+        on: 
+          type: string
+          format: date-time
+        references: 
+          type: array
+          items: 
+            type: object
+            additionalProperties: false
+            properties: 
+              name: 
+                type: string
+              value: 
+                type: string
+    
+    EventStatus:
+      type: string
+      enum:
+          - pre-event
+          - mid-event
+          - post-event
+          - postponed
+          - suspended
+          - halted
+          - forfeited
+          - rescheduled
+          - delayed
+          - canceled
+          - intermission
+          - if-necessary
+          - discarded
+          
+                
+    EventDetails:
+      type: object
+      properties:
+        eventstatus:
+          $ref: '#/components/schemas/EventStatus'
+        dates:
+            $ref: '#/components/schemas/datesobjectType'
+        organiser:
+            $ref: '#/components/schemas/OrganisationType'
+
+      additionalProperties: false
+      
+      
+      
+    Eventheadlines:
+      type: array
+      items:
+        type: object
+        required: [value]
+        additionalProperties: false
+        properties:
+          role:
+            type: string
+            title: Role
+          contenttype:
+            type: string
+            title: Content Type
+          value:
+            type: string
+            title: Value
+          
+    EventPlaces:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            
+          rel:
+            type: string
+            
+          uri:
+            type: string
+            format: uri
+            
+          literal:
+            type: string
+            
+          contactinfo:
+            type: array
+            items:
+              $ref: '#/components/schemas/contactinfoType'
+          geojson:
+            $ref: 'https://geojson.org/schema/GeoJSON.json#'
+        additionalProperties: false
+        
+        
+    Eventpeople:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            type: string
+            
+          rel:
+            type: string
+            
+          uri:
+            type: string
+            format: uri
+            
+          literal:
+            type: string
+            
+          contactinfo:
+            type: array
+            items:
+              $ref: '#/components/schemas/contactinfoType'
+            
+    EventSubjects:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            
+          rel:
+            type: string
+
+          uri:
+            type: string
+            format: uri
+            
+          literal:
+            type: string
+            
+          creator:
+            type: string
+
+          relevance:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+
+          confidence:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+            
+        additionalProperties: false
+
+        
+    EventPlannedCoverage:
+      type: array
+      items:
+        type: object
+        properties:
+          uri:
+            type: string
+          title:
+            type: string
+          pubstatus:
+            type: string
+            enum:
+              - usable
+              - withheld
+              - canceled  
+          commissioned: 
+            $ref: '#/components/schemas/EventcommissionedType'
+            
+          dates:
+            $ref: '#/components/schemas/datesobjectType'
+
+          type:
+            type: string
+
+          event:
+            type: string
+          audiences:
+            type: array
+            items:
+              type: object
+              properties:
+                audience:
+                  type: string
+                significance:
+                  type: integer
+                  format: int32
+
+              additionalProperties: false
+          exclaudience:
+            type: array
+            items:
+              type: string
+
+          headline:
+            type: string
+
+          ednote:
+            type: string
+
+          urgency:
+            type: string
+
+          language:
+            type: string
+
+          scheduled:
+            type: string
+          
+          services:
+            type: array
+            items:
+              type: string
+          
+          assignedto:
+            type: string
+          
+          itemcount:
+            type: object
+            properties:
+              rangefrom:
+                type: integer
+                format: int32
+              rangeto:
+                type: integer
+                format: int32
+          
+          wordcount:
+            type: integer
+            format: int32
+          
+          renditions:
+            type: array
+            items:
+              $ref: '#/components/schemas/EventRenditionType'
+    
+    
+    
+    EventObjects:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            
+          rel:
+            type: string
+            
+          uri:
+            type: string
+            format: uri
+            
+          literal:
+            type: string
+            
+        additionalProperties: false
+      
+    Eventinfosources:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            type: string
+            
+          role:
+            type: string
+            
+          uri:
+            type: string
+            
+            format: uri
+          literal:
+            type: string
+            
+          contactinfo:
+            type: array
+            items:
+              $ref: '#/components/schemas/contactinfoType'
+              
+    Eventassociations:
+      type: array
+      items: 
+        allOf:
+          - $ref: '#/components/schemas/Event'
+          - type: object
+            properties: 
+              name: 
+                type: string
+                description: Name of associated object
+            required: 
+              - name
+              - uri
+        additionalProperties: false
+        
+    Eventtrustindicators: 
+      title: Trust indicators
+      
+      type: array
+      items: 
+        type: object
+        additionalProperties: false
+        properties: 
+          role: 
+            title: Role
+            
+            type: string
+            format: uri
+          title: 
+            title: Title
+            
+            type: string
+          href: 
+            title: href
+            
+            type: string
+            format: uri
+    Eventstandard: 
+      title: Standard
+      type: object
+      
+      additionalProperties: false
+      properties: 
+        name: 
+          title: Name of standard.
+          
+          type: string
+        version: 
+          title: Version of standard.
+          
+          type: string
+        schema: 
+          title: Schema
+          
+          type: string
+          format: uri
+    Eventgenres: 
+      title: Genres
+      
+      type: array
+      items: 
+        type: object
+        additionalProperties: false
+        properties: 
+          name: 
+            title: Name
+            
+            type: string
+          uri: 
+            title: URI
+            
+            type: string
+          literal: 
+            title: Literal
+            
+            type: string
+    Eventrightsinfo: 
+      title: Rights information
+      type: object
+      
+      properties: 
+        langid: 
+          type: string
+          title: Language id
+          
+          format: uri
+        linkedrights: 
+          title: Linked rights
+          
+          type: string
+          format: uri
+        encodedrights: 
+          title: Encoded Rights
+          type: string
+          
+      oneOf: [
+          required: [
+            linkedrights
+          ],
+          required: [
+            encodedrights
+          ]
+      ]
+              
+      
+    truncatedDateTimeType:
+      type: string
+      
+    contactinfoType:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+        
+        role:
+          type: string
+         
+        lang:
+          type: string
+         
+        name:
+          type: string
+         
+        value:
+          type: string
+         
+        address:
+          type: object
+          description: The address of a person, place or organisation.
+          additionalProperties: false
+          properties:
+            lines:
+              type: array
+              
+              items:
+                type: string
+                
+            locality:
+              type: string
+             
+            area:
+              type: string
+              
+            postalcode:
+              type: string
+              
+            country:
+              type: string
+              
+      oneOf:
+        - required: [value]
+        - required: [address]
+        
+        
+    datesobjectType:
+      type: object
+      additionalProperties: false
+      properties:
+        startdate:
+          $ref: '#/components/schemas/truncatedDateTimeType'
+        enddate:
+            $ref: '#/components/schemas/truncatedDateTimeType'
+        duration:
+          
+          type: string
+        recurrence:
+          type: object
+          
+          properties:
+            recurrence-dates:
+              type: array
+              
+              items:
+                $ref: '#/components/schemas/truncatedDateTimeType'
+            recurrence-rules:
+              type: array
+              
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  frequency:
+                    type: string
+                    
+                    enum:
+                      - secondly
+                      - minutely
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                  interval:
+                    type: string
+                       
+                  until:
+                    type: string
+                      
+                  count:
+                    type: string
+    
+
+    OrganisationType:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+            
+        rel:
+          type: string
+            
+        uri:
+          type: string
+            
+          format: uri
+        literal:
+          type: string
+            
+        symbols:
+          type: array
+            
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              ticker:
+                type: string
+                  
+              exchange:
+                type: string
+                  
+              symboltype:
+                type: string
+                  
+                format: uri
+              symbol:
+                type: string
+
+        contactinfo:
+          type: array
+          items:
+            $ref: '#/components/schemas/contactinfoType'


### PR DESCRIPTION
1) Reuters brought some gaps w.r.t to Pubstatus attributes in Ninjs 2.2 
Since current status is in main Events body and only has 3 status which doest suffice reuters ask>
As there are other status being used - 
Also a concern wa raised should this status be in main event section or should be moved to Planned coverage - 

Based on this disussion following changes has been done - 
Pubstatus has been moved under planned coverage 
and a new EventStatus has been added under Event Details Based 
on : https://cv.iptc.org/newscodes/speventstatus/
 "pubstatus": {
          "title": "Publication status",
          "description": "The publishing status of the news object, its value is *usable* by default. nar:pubStatus",
          "type": "string",
          "enum": [
            "usable",
            "withheld",
            "canceled"
          ]


2) Arqiva submitted changes related to SRT protocol flow attributes which was requested to be added .
Based on these requested changes transport protocol - Rest attributes will be added later 

transportprotocol: 
          type: string
          enum: 
            - srtlistener
            - srtcaller